### PR TITLE
Iterate values of sealed string params to avoid manual mapping

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/EnumStringParam.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/EnumStringParam.scala
@@ -1,0 +1,21 @@
+package ml.combust.mleap.core.feature
+
+/**
+ * Lower-cases the name of any extending sealed trait case class.
+ *
+ * find() can be used to map back from a lower-cased string.
+ */
+trait EnumStringParam extends Product {
+
+  def asParamString: String = {
+    this.productPrefix.toLowerCase
+  }
+
+  def find[T <: EnumStringParam](value: String, values: Set[T]) = {
+    values.find(_.productPrefix.toLowerCase == value)
+      .getOrElse(throw new IllegalArgumentException(s"Invalid handler: $value"))
+  }
+
+  def fromString(value: String): EnumStringParam
+
+}

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringIndexerModel.scala
@@ -1,33 +1,20 @@
 package ml.combust.mleap.core.feature
 
+import ca.mrvisser.sealerate
 import ml.combust.mleap.core.Model
 import ml.combust.mleap.core.types.{ScalarType, StructType}
 
-sealed trait HandleInvalid {
-  def asParamString: String
+
+sealed trait HandleInvalid extends EnumStringParam {
+  def fromString(value: String): HandleInvalid = find(value, sealerate.values[HandleInvalid])
 }
 
 object HandleInvalid {
   val default = Error
 
-  case object Error extends HandleInvalid {
-    override def asParamString: String = "error"
-  }
-
-  case object Skip extends HandleInvalid {
-    override def asParamString: String = "skip"
-  }
-
-  case object Keep extends HandleInvalid {
-    override def asParamString: String = "keep"
-  }
-
-  def fromString(value: String): HandleInvalid = value match {
-    case "error" => HandleInvalid.Error
-    case "skip" => HandleInvalid.Skip
-    case "keep" => HandleInvalid.Keep
-    case _ => throw new IllegalArgumentException(s"Invalid handler: $value")
-  }
+  case object Error extends HandleInvalid
+  case object Skip extends HandleInvalid
+  case object Keep extends HandleInvalid
 }
 
 /** Class for string indexer model.

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringMapModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/StringMapModel.scala
@@ -3,27 +3,20 @@ package ml.combust.mleap.core.feature
 import ml.combust.mleap.core.Model
 import ml.combust.mleap.core.types.{ScalarType, StructType}
 
-sealed trait StringMapHandleInvalid {
-  def asParamString: String
+import language.experimental.macros
+import ca.mrvisser.sealerate
+
+
+sealed trait StringMapHandleInvalid extends EnumStringParam {
+  def fromString(value: String): StringMapHandleInvalid = find(value, sealerate.values[StringMapHandleInvalid])
 }
 
 object StringMapHandleInvalid {
   val default = Error
   val defaultValue = 0.0
 
-  case object Error extends StringMapHandleInvalid {
-    override def asParamString: String = "error"
-  }
-
-  case object Keep extends StringMapHandleInvalid {
-    override def asParamString: String = "keep"
-  }
-
-  def fromString(value: String): StringMapHandleInvalid = value match {
-    case "error" => StringMapHandleInvalid.Error
-    case "keep" => StringMapHandleInvalid.Keep
-    case _ => throw new IllegalArgumentException(s"Invalid handler: $value")
-  }
+  case object Error extends StringMapHandleInvalid
+  case object Keep extends StringMapHandleInvalid
 }
 
 /** Class for string map model.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,6 +40,7 @@ object Dependencies {
       "org.tensorflow" % "libtensorflow" % tensorflowVersion,
       "org.tensorflow" % "libtensorflow_jni" % tensorflowVersion
     )
+    val sealerate = "ca.mrvisser" %% "sealerate" % "0.0.5"
 
     val akkaTestKit = "com.typesafe.akka" %% "akka-testkit" % akkaVersion
     val akkaStreamTestKit = "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion
@@ -98,7 +99,7 @@ object Dependencies {
 
   val base = l ++= Seq()
 
-  val core = l ++= Seq(sparkMllibLocal, jTransform, Test.scalaTest)
+  val core = l ++= Seq(sparkMllibLocal, jTransform, Test.scalaTest, sealerate)
 
   def runtime(scalaVersion: SettingKey[String]) = l ++= (Seq(Test.scalaTest, Test.junit, Test.junitInterface, commonsIo) ++ scalaReflect.modules(scalaVersion.value))
 


### PR DESCRIPTION
I wanted to simplify the code of mleap `Model`s to avoid manual mapping of "enum"-type params. This is as far as I was able to generalize the code.

This way the sealed trait "enums" can be provided with generic methods to map to & from their lower-case string representation.

I applied it for 2 `Model`s for now, but probably there would be more cases that could use this, if it makes sense.

I'm not sure if this is the best that can be achieved in scala in a type safe way(?). Currently the `sealerate.values` must still be called manually by each sealed trait, but ideally even that would be covered by `EnumStringParam`, so that the extenders of `EnumStringParam` wouldn't need to implement _any_ method (unless they want something else of course).

In Java this would be easier with enums I presume.